### PR TITLE
fix space created by `.PostUser-level {margin-top: 75px}` after upgrade to flarum 1.8 from 1.6

### DIFF
--- a/resources/less/forum.less
+++ b/resources/less/forum.less
@@ -1,8 +1,7 @@
 .PostUser-level {
-    float: left;
-    position: relative;
-    margin-left: -80px;
-    margin-top: 75px;
+    position: absolute;
+    left: -85px;
+    top: 75px;
     width: 64px;
     text-align: center;
 }


### PR DESCRIPTION
![image](https://github.com/imorland/level-ranks/assets/13030387/509290d5-c13f-4438-9791-a7b904c0f8e2)
